### PR TITLE
TYPO3 v13 Compatibility

### DIFF
--- a/Configuration/user.tsconfig
+++ b/Configuration/user.tsconfig
@@ -1,0 +1,1 @@
+options.pageTree.doktypesToShowInNewPageDragArea := addToList(132)

--- a/composer.json
+++ b/composer.json
@@ -29,8 +29,8 @@
 	],
 	"require": {
 		"php": "^8.1",
-		"typo3/cms-core": "^12.4",
-		"lochmueller/calendarize": "^13.0"
+		"typo3/cms-core": "^13.4",
+		"lochmueller/calendarize": "@dev"
 	},
 	"replace": {
 		"typo3-ter/calendarize-pages": "self.version"

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -13,8 +13,8 @@ $EM_CONF[$_EXTKEY] = [
     'author_email' => 'tim@fruit-lab.de',
     'constraints' => [
         'depends' => [
-            'typo3' => '12.0.0-12.5.99',
-            'php' => '7.4.0-8.0.99',
+            'typo3' => '13.0.0-13.5.99',
+            'php' => '8.1.0-8.3.99',
             'calendarize' => '10.0.0-13.99.99',
         ],
     ],

--- a/ext_tables.php
+++ b/ext_tables.php
@@ -6,7 +6,3 @@ $GLOBALS['PAGES_TYPES'][132] = [
     'type' => 'web',
     'allowedTables' => '*',
 ];
-
-\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addUserTSConfig('
-    options.pageTree.doktypesToShowInNewPageDragArea := addToList(132)
-');


### PR DESCRIPTION
Begin with TYPO3 v13 compatibility

- Bump version for TYPO3 and PHP 
- Move user.tsconfig to own file (due to future deprecation)

