### PR TITLE
[TASK] Add location and organizer links to event page

### DIFF
--- a/Classes/Domain/Model/Page.php
+++ b/Classes/Domain/Model/Page.php
@@ -19,6 +19,14 @@ class Page extends AbstractEntity
 
     protected string $author = '';
 
+    protected string $location = '';
+
+    protected string $locationLink = '';
+
+    protected string $organizer = '';
+
+    protected string $organizerLink = '';
+
     /**
      * @var ObjectStorage<Category>
      */
@@ -98,5 +106,45 @@ class Page extends AbstractEntity
     public function getCategories(): ObjectStorage
     {
         return $this->categories;
+    }
+
+    public function getLocation(): string
+    {
+        return $this->location;
+    }
+
+    public function setLocation(string $location): void
+    {
+        $this->location = $location;
+    }
+
+    public function getOrganizer(): string
+    {
+        return $this->organizer;
+    }
+
+    public function setOrganizer(string $organizer): void
+    {
+        $this->organizer = $organizer;
+    }
+
+    public function getLocationLink(): string
+    {
+        return $this->locationLink;
+    }
+
+    public function setLocationLink(string $locationLink): void
+    {
+        $this->locationLink = $locationLink;
+    }
+
+    public function getOrganizerLink(): string
+    {
+        return $this->organizerLink;
+    }
+
+    public function setOrganizerLink(string $organizerLink): void
+    {
+        $this->organizerLink = $organizerLink;
     }
 }

--- a/Configuration/TCA/Overrides/pages.php
+++ b/Configuration/TCA/Overrides/pages.php
@@ -42,3 +42,57 @@ $GLOBALS['TCA']['pages']['types']['132']['columnsOverrides'] = [
         ],
     ],
 ];
+
+$additionalTCAcolumns = [
+    'location' => [
+        'exclude' => true,
+        'label' => $ll . 'tx_calendarize_domain_model_event.location',
+        'config' => [
+            'type' => 'input',
+        ],
+    ],
+    'location_link' => [
+        'exclude' => true,
+        'label' => $ll . 'tx_calendarize_domain_model_event.location_link',
+        'config' => [
+            'type' => 'link',
+        ],
+    ],
+    'organizer' => [
+        'exclude' => true,
+        'label' => $ll . 'tx_calendarize_domain_model_event.organizer',
+        'config' => [
+            'type' => 'input',
+        ],
+    ],
+    'organizer_link' => [
+        'exclude' => true,
+        'label' => $ll . 'tx_calendarize_domain_model_event.organizer_link',
+        'config' => [
+            'type' => 'link',
+        ],
+    ],
+];
+
+$GLOBALS['TCA']['pages'] = [
+    'palettes' => [
+        'location' => [
+            'showitem' => 'location,location_link',
+        ],
+        'organizer' => [
+            'showitem' => 'organizer,organizer_link',
+        ],
+    ],
+];
+
+ExtensionManagementUtility::addTCAcolumns(
+    'pages',
+    $additionalTCAcolumns
+);
+
+ExtensionManagementUtility::addToAllTCAtypes(
+    'pages',
+    '--palette--;;location, --palette--;;organizer',
+    '132',
+    'before:calendarize'
+);

--- a/ext_tables.sql
+++ b/ext_tables.sql
@@ -3,5 +3,9 @@
 #
 CREATE TABLE pages
 (
-	calendarize tinytext
+    `location`         text         DEFAULT NULL,
+    `location_link`    text         DEFAULT NULL,
+    `organizer`        text         DEFAULT NULL,
+    `organizer_link`   text         DEFAULT NULL,
+    `calendarize`      tinytext     DEFAULT NULL
 );


### PR DESCRIPTION
To create equivalent editing processes when using events as records or pages the missing fields location, location_link, organizer and organizer_link were added to the TCA configuration of event pages exactly like they are registered in the calendarize extension to avoid any issues.