### PR TITLE
[BUGFIX] Set correct locallang file path for additional event fields

### DIFF
--- a/Configuration/TCA/Overrides/pages.php
+++ b/Configuration/TCA/Overrides/pages.php
@@ -46,28 +46,28 @@ $GLOBALS['TCA']['pages']['types']['132']['columnsOverrides'] = [
 $additionalTCAcolumns = [
     'location' => [
         'exclude' => true,
-        'label' => $ll . 'tx_calendarize_domain_model_event.location',
+        'label' => 'LLL:EXT:calendarize/Resources/Private/Language/locallang.xlf:tx_calendarize_domain_model_event.location',
         'config' => [
             'type' => 'input',
         ],
     ],
     'location_link' => [
         'exclude' => true,
-        'label' => $ll . 'tx_calendarize_domain_model_event.location_link',
+        'label' => 'LLL:EXT:calendarize/Resources/Private/Language/locallang.xlf:tx_calendarize_domain_model_event.location_link',
         'config' => [
             'type' => 'link',
         ],
     ],
     'organizer' => [
         'exclude' => true,
-        'label' => $ll . 'tx_calendarize_domain_model_event.organizer',
+        'label' => 'LLL:EXT:calendarize/Resources/Private/Language/locallang.xlf:tx_calendarize_domain_model_event.organizer',
         'config' => [
             'type' => 'input',
         ],
     ],
     'organizer_link' => [
         'exclude' => true,
-        'label' => $ll . 'tx_calendarize_domain_model_event.organizer_link',
+        'label' => 'LLL:EXT:calendarize/Resources/Private/Language/locallang.xlf:tx_calendarize_domain_model_event.organizer_link',
         'config' => [
             'type' => 'link',
         ],

--- a/Configuration/TCA/Overrides/pages.php
+++ b/Configuration/TCA/Overrides/pages.php
@@ -74,16 +74,17 @@ $additionalTCAcolumns = [
     ],
 ];
 
-$GLOBALS['TCA']['pages'] = [
-    'palettes' => [
+ArrayUtility::mergeRecursiveWithOverrule(
+    $GLOBALS['TCA']['pages']['palettes'],
+    [
         'location' => [
             'showitem' => 'location,location_link',
         ],
         'organizer' => [
             'showitem' => 'organizer,organizer_link',
         ],
-    ],
-];
+    ]
+);
 
 ExtensionManagementUtility::addTCAcolumns(
     'pages',


### PR DESCRIPTION
Because the `$ll` was never defined it can't be resolved. Using
the complete path of the fields label now not only fixes the
currently occurring TYPO3 error but also shows the correct label
for each field.